### PR TITLE
Changed the minimum required version of vim from 7.0 to 7.3 because strwidth() is required

### DIFF
--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -22,8 +22,8 @@
 " THE SOFTWARE.
 " }}}
 
-if v:version < 700
-	echoerr printf('Vim 7 is required for buftabline (this is only %d.%d)',v:version/100,v:version%100)
+if v:version < 703
+	echoerr printf('Vim 7.3 is required for buftabline (this is only %d.%d)',v:version/100,v:version%100)
 	finish
 endif
 


### PR DESCRIPTION
strwidth() is used in the code which wasn't introduced until 7.3. So trying to load this plugin on, for example, vim 7.2 causes errors when loading vim.