### PR TITLE
g:buftabline_number = 2 to show sequential numbers

### DIFF
--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -49,6 +49,7 @@ endfunction
 let s:prev_currentbuf = winbufnr(0)
 function! buftabline#render()
 	let show_num = g:buftabline_numbers
+	let show_serial_num = g:buftabline_numbers == 2
 	let show_mod = g:buftabline_indicators
 	let lpad     = g:buftabline_separators ? nr2char(0x23B8) : ' '
 
@@ -58,7 +59,9 @@ function! buftabline#render()
 	let tabs = []
 	let tabs_by_tail = {}
 	let currentbuf = winbufnr(0)
+	let screen_num = 0
 	for bufnum in bufnums
+		let screen_num = show_serial_num ? screen_num + 1 : bufnum
 		let tab = { 'num': bufnum }
 		let tab.hilite = currentbuf == bufnum ? 'Current' : bufwinnr(bufnum) > 0 ? 'Active' : 'Hidden'
 		let bufpath = bufname(bufnum)
@@ -68,16 +71,16 @@ function! buftabline#render()
 			if strlen(suf) | let bufpath = fnamemodify(bufpath, ':h') | endif
 			let tab.head = fnamemodify(bufpath, ':h')
 			let tab.tail = fnamemodify(bufpath, ':t')
-			let pre = ( show_mod && getbufvar(bufnum, '&mod') ? '+' : '' ) . ( show_num ? bufnum : '' )
+			let pre = ( show_mod && getbufvar(bufnum, '&mod') ? '+' : '' ) . ( show_num ? screen_num : '' )
 			if strlen(pre) | let pre .= ' ' | endif
 			let tab.fmt = lpad . pre . '%s' . suf . ' '
 			let tabs_by_tail[tab.tail] = get(tabs_by_tail, tab.tail, []) + [tab]
 		elseif -1 < index(['nofile','acwrite'], getbufvar(bufnum, '&buftype')) " scratch buffer
-			let tab.label = lpad . ( show_num ? show_mod ? '!' . bufnum . ' ' : bufnum . ' ! ' : '! ' )
+			let tab.label = lpad . ( show_num ? show_mod ? '!' . screen_num . ' ' : screen_num . ' ! ' : '! ' )
 		else " unnamed file
 			let tab.label = lpad
 						\ . ( show_mod && getbufvar(bufnum, '&mod') ? '+' : '' )
-						\ . ( show_num ? bufnum . ' ' : '* ' )
+						\ . ( show_num ? screen_num . ' ' : '* ' )
 		endif
 		let tabs += [tab]
 	endfor


### PR DESCRIPTION
I wanted to make key bindings to jump to an other buffer quickly like below.
```
nn <leader>1 :exe 'b'.buftabline#user_buffers()[0]<cr>
nn <leader>2 :exe 'b'.buftabline#user_buffers()[1]<cr>
nn <leader>3 :exe 'b'.buftabline#user_buffers()[2]<cr>
```

However, I found it's hard to know the sequential index of a buffer when there are a lot of ones, so I added some code to show sequential numbers.