### PR TITLE
add plugs for selecting buffers with ordinal numbers.

### DIFF
--- a/doc/buftabline.txt
+++ b/doc/buftabline.txt
@@ -47,6 +47,18 @@ effect immediately unless you force an update: >
     the |:ls| command, whereas the ordinal number is a simple sequential count
     from left to right.
 
+    If you want to select buffers with ordinal numbers you can bind your
+    number keys for convenience:
+            nmap <leader>1 <Plug>BufTabLineSelectBuffer1
+            nmap <leader>2 <Plug>BufTabLineSelectBuffer2
+            nmap <leader>3 <Plug>BufTabLineSelectBuffer3
+            nmap <leader>4 <Plug>BufTabLineSelectBuffer4
+            nmap <leader>5 <Plug>BufTabLineSelectBuffer5
+            nmap <leader>6 <Plug>BufTabLineSelectBuffer6
+            nmap <leader>7 <Plug>BufTabLineSelectBuffer7
+            nmap <leader>8 <Plug>BufTabLineSelectBuffer8
+            nmap <leader>9 <Plug>BufTabLineSelectBuffer9
+
 
 *g:buftabline_indicators*    boolean (default off)
 

--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -186,3 +186,13 @@ autocmd BufAdd    * call buftabline#update(0)
 autocmd BufDelete * call buftabline#update(1)
 autocmd TabEnter  * call buftabline#update(0)
 autocmd VimEnter  * call buftabline#update(0)
+
+noremap <silent> <Plug>BufTabLineSelectBuffer1 :exe 'b'.buftabline#user_buffers()[0]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer2 :exe 'b'.buftabline#user_buffers()[1]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer3 :exe 'b'.buftabline#user_buffers()[2]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer4 :exe 'b'.buftabline#user_buffers()[3]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer5 :exe 'b'.buftabline#user_buffers()[4]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer6 :exe 'b'.buftabline#user_buffers()[5]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer7 :exe 'b'.buftabline#user_buffers()[6]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer8 :exe 'b'.buftabline#user_buffers()[7]<cr>
+noremap <silent> <Plug>BufTabLineSelectBuffer9 :exe 'b'.buftabline#user_buffers()[8]<cr>


### PR DESCRIPTION
Fixes #17 

I have created plugs for selecting buffers with ordinal numbers as described in https://github.com/ap/vim-buftabline/pull/11. Feel free to change plug names if you don't like ```BufTabLineSelectBufferX```.

I put following into my config to use it:
```
nmap <leader>1 <Plug>BufTabLineSelectBuffer1
nmap <leader>2 <Plug>BufTabLineSelectBuffer2
nmap <leader>3 <Plug>BufTabLineSelectBuffer3
nmap <leader>4 <Plug>BufTabLineSelectBuffer4
nmap <leader>5 <Plug>BufTabLineSelectBuffer5
nmap <leader>6 <Plug>BufTabLineSelectBuffer6
nmap <leader>7 <Plug>BufTabLineSelectBuffer7
nmap <leader>8 <Plug>BufTabLineSelectBuffer8
nmap <leader>9 <Plug>BufTabLineSelectBuffer9
```