### PR TITLE
Allow separator character to be specified

### DIFF
--- a/doc/buftabline.txt
+++ b/doc/buftabline.txt
@@ -64,8 +64,8 @@ effect immediately unless you force an update: >
 
 *g:buftabline_separators_char*    string (default nr2char(0x23B8))
 
-    Can be used to specify the character or string to be used as the
-    separator between tabs. The default is U+23B8 LEFT VERTICAL BOX LINE.
+    Specifies the character or string to use as the separator between tabs.
+    The default is U+23B8 LEFT VERTICAL BOX LINE.
 
 ==============================================================================
 2. Mappings                                                *buftabline-mappings*

--- a/doc/buftabline.txt
+++ b/doc/buftabline.txt
@@ -62,6 +62,10 @@ effect immediately unless you force an update: >
     left side of each tab with U+23B8 LEFT VERTICAL BOX LINE. Therefore the
     separator will be highlighted the same way as the tab to its left.)
 
+*g:buftabline_separators_char*    string (default nr2char(0x23B8))
+
+    Can be used to specify the character or string to be used as the
+    separator between tabs. The default is U+23B8 LEFT VERTICAL BOX LINE.
 
 ==============================================================================
 2. Mappings                                                *buftabline-mappings*

--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -37,10 +37,11 @@ hi default link BufTabLineActive  PmenuSel
 hi default link BufTabLineHidden  TabLine
 hi default link BufTabLineFill    TabLineFill
 
-let g:buftabline_numbers    = get(g:, 'buftabline_numbers',    0)
-let g:buftabline_indicators = get(g:, 'buftabline_indicators', 0)
-let g:buftabline_separators = get(g:, 'buftabline_separators', 0)
-let g:buftabline_show       = get(g:, 'buftabline_show',       2)
+let g:buftabline_numbers         = get(g:, 'buftabline_numbers',    0)
+let g:buftabline_indicators      = get(g:, 'buftabline_indicators', 0)
+let g:buftabline_separators      = get(g:, 'buftabline_separators', 0)
+let g:buftabline_separators_char = get(g:, 'buftabline_separators_char', nr2char(0x23B8))
+let g:buftabline_show            = get(g:, 'buftabline_show',       2)
 
 function! buftabline#user_buffers() " help buffers are always unlisted, but quickfix buffers are not
 	return filter(range(1,bufnr('$')),'buflisted(v:val) && "quickfix" !=? getbufvar(v:val, "&buftype")')
@@ -51,7 +52,7 @@ function! buftabline#render()
 	let show_num = g:buftabline_numbers == 1
 	let show_ord = g:buftabline_numbers == 2
 	let show_mod = g:buftabline_indicators
-	let lpad     = g:buftabline_separators ? nr2char(0x23B8) : ' '
+	let lpad     = g:buftabline_separators ? g:buftabline_separators_char : ' '
 
 	let bufnums = buftabline#user_buffers()
 


### PR DESCRIPTION
Not all fonts contain the Unicode character U+23B8 (LEFT VERTICAL BOX LINE) which is currently hard-coded as the separator between tabs. For such a case, it would be nice to allow the users to specify an alternative. For instance, I'm using U+258C (LEFT HALF BLOCK) instead.

**Usage**

```
let g:buftabline_separators = 1
let g:buftabline_separators_char = '▌'
```

or 

```
let g:buftabline_separators = 1
let g:buftabline_separators_char = nr2char(0x258C)
```

**Result** 
![image](https://cloud.githubusercontent.com/assets/4657140/16631385/c2ec24d8-4373-11e6-837a-70044e66de53.png)
