### PR TITLE
Enable Modified Hilite Group

### DIFF
--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -32,10 +32,11 @@ scriptencoding utf-8
 augroup BufTabLine
 autocmd!
 
-hi default link BufTabLineCurrent TabLineSel
-hi default link BufTabLineActive  PmenuSel
-hi default link BufTabLineHidden  TabLine
-hi default link BufTabLineFill    TabLineFill
+hi default link BufTabLineCurrent   TabLineSel
+hi default link BufTabLineActive    PmenuSel
+hi default link BufTabLineHidden    TabLine
+hi default link BufTabLineFill      TabLineFill
+hi default link BufTabLineModified  TabLine
 
 let g:buftabline_numbers    = get(g:, 'buftabline_numbers',    0)
 let g:buftabline_indicators = get(g:, 'buftabline_indicators', 0)
@@ -66,7 +67,7 @@ function! buftabline#render()
 	for bufnum in bufnums
 		let screen_num = show_num ? bufnum : show_ord ? screen_num + 1 : ''
 		let tab = { 'num': bufnum }
-		let tab.hilite = currentbuf == bufnum ? 'Current' : bufwinnr(bufnum) > 0 ? 'Active' : 'Hidden'
+		let tab.hilite = currentbuf == bufnum ? 'Current' : show_mod && getbufvar(bufnum, '&mod') ? 'Modified' : bufwinnr(bufnum) > 0 ? 'Active' : 'Hidden'
 		if currentbuf == bufnum | let [centerbuf, s:centerbuf] = [bufnum, bufnum] | endif
 		let bufpath = bufname(bufnum)
 		if strlen(bufpath)


### PR DESCRIPTION
Hey, thanks for this plugin! I know this is completely unsolicited, but had seen an issue where this kind of thing was mentioned. This PR enables a hilite group for tabs that are modified. The order of precedence is shown below.

![image](https://user-images.githubusercontent.com/175278/31195324-de0d031a-a941-11e7-8b50-1f55b3d8d80e.png)
1. current
2. active
3. modified
4. hidden

I did see in #29 that you were talking about rewriting the display logic, so feel free to ignore this - regardless 😄 

