### PR TITLE
use <abuf> to identify buffer during events

### DIFF
--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -2,17 +2,17 @@
 " Licence:     The MIT License (MIT)
 " Commit:      $Format:%H$
 " {{{ Copyright (c) 2015 Aristotle Pagaltzis <pagaltzis@gmx.de>
-" 
+"
 " Permission is hereby granted, free of charge, to any person obtaining a copy
 " of this software and associated documentation files (the "Software"), to deal
 " in the Software without restriction, including without limitation the rights
 " to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 " copies of the Software, and to permit persons to whom the Software is
 " furnished to do so, subject to the following conditions:
-" 
+"
 " The above copyright notice and this permission notice shall be included in
 " all copies or substantial portions of the Software.
-" 
+"
 " THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 " IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 " FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -160,7 +160,7 @@ function! buftabline#update(deletion)
 	elseif 1 == g:buftabline_show
 		let bufnums = buftabline#user_buffers()
 		let total = len(bufnums)
-		if a:deletion && -1 < index(bufnums, bufnr('%'))
+		if a:deletion && -1 < index(bufnums, str2nr(expand('<abuf>')))
 			" BufDelete triggers before buffer is deleted
 			" so if current buffer is a user buffer, it must be subtracted
 			let total -= 1


### PR DESCRIPTION
This should fix #39 - `lclose` can sometimes cause the tabline to
disappear even when there are multiple buffers remaining. Essentially
the problem is buftabline always assumes the buffer being deleted is the
current buffer, which is generally true, but not always true.

`bufnr('%')` gives us the number of the _current_ buffer which is not
necessarily the buffer that is being added or deleted. `expand('<abuf>')`
gives us the number of buffer on which the event is operating, but as a
string - so we need to convert it to a number with `str2nr`. We can then
determine if the actual buffer being deleted is a user buffer or not.

I unintentionally committed some changes deleting some trailing
whitespace - let me know if you want me to revert those lines.