### PR TITLE
Add buftabline_path support

### DIFF
--- a/doc/buftabline.txt
+++ b/doc/buftabline.txt
@@ -71,6 +71,13 @@ effect immediately unless you force an update: >
     not if you change it later.
 
 
+*g:buftabline_path*      number (default 0)
+
+    When on, the parent directory is always shown in the buffer label:
+            0: only show the parent directory for ambiguous filenames
+            1: always show the parent directory in buffer labels
+
+
 ==============================================================================
 3. Mappings                                                *buftabline-mappings*
 

--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -42,6 +42,7 @@ let g:buftabline_indicators = get(g:, 'buftabline_indicators', 0)
 let g:buftabline_separators = get(g:, 'buftabline_separators', 0)
 let g:buftabline_show       = get(g:, 'buftabline_show',       2)
 let g:buftabline_plug_max   = get(g:, 'buftabline_plug_max',  10)
+let g:buftabline_path       = get(g:, 'buftabline_path',  0)
 
 function! buftabline#user_buffers() " help buffers are always unlisted, but quickfix buffers are not
 	return filter(range(1,bufnr('$')),'buflisted(v:val) && "quickfix" !=? getbufvar(v:val, "&buftype")')
@@ -73,7 +74,16 @@ function! buftabline#render()
 		if strlen(bufpath)
 			let tab.path = fnamemodify(bufpath, ':p:~:.')
 			let tab.sep = strridx(tab.path, s:dirsep, strlen(tab.path) - 2) " keep trailing dirsep
-			let tab.label = tab.path[tab.sep + 1:]
+			if 1 == g:buftabline_path
+				let s = split(tab.path, '/')
+				if len(s) > 1
+					let tab.label = s[-2] . '/' . s[-1]
+				else
+					let tab.label = s[-1]
+				endif
+			else
+				let tab.label = tab.path[tab.sep + 1:]
+			endif
 			let pre = ( show_mod && getbufvar(bufnum, '&mod') ? '+' : '' ) . screen_num
 			let tab.pre = strlen(pre) ? pre . ' ' : ''
 			let tabs_per_tail[tab.label] = get(tabs_per_tail, tab.label, 0) + 1


### PR DESCRIPTION
I wanted an option to always show the parent directory names in the buffer labels, so I added a `g:buftabline_path` option.  Not sure if you want this in the project, but I figured I'd send a PR just in case. 🙂 