### PR TITLE
close BufTabLine autocmd group

### DIFF
--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -29,9 +29,6 @@ endif
 
 scriptencoding utf-8
 
-augroup BufTabLine
-autocmd!
-
 hi default link BufTabLineCurrent TabLineSel
 hi default link BufTabLineActive  PmenuSel
 hi default link BufTabLineHidden  TabLine
@@ -168,10 +165,13 @@ function! buftabline#update(zombie)
 	set tabline=%!buftabline#render()
 endfunction
 
+augroup BufTabLine
+autocmd!
 autocmd VimEnter  * call buftabline#update(0)
 autocmd TabEnter  * call buftabline#update(0)
 autocmd BufAdd    * call buftabline#update(0)
 autocmd BufDelete * call buftabline#update(str2nr(expand('<abuf>')))
+augroup END
 
 for s:n in range(1, g:buftabline_plug_max) + ( g:buftabline_plug_max > 0 ? [-1] : [] )
 	let s:b = s:n == -1 ? -1 : s:n - 1


### PR DESCRIPTION
I noticed the autocmd group wasn't closed, so I added the closing `augroup END` and moved the augroup declarations to the site of the autocmds themselves.