### PR TITLE
improve compatability with Goyo

### DIFF
--- a/plugin/buftabline.vim
+++ b/plugin/buftabline.vim
@@ -150,12 +150,13 @@ endfunction
 
 function! buftabline#update(zombie)
 	set tabline=
-	if tabpagenr('$') > 1 | set guioptions+=e showtabline=2 | return | endif
 	set guioptions-=e
 	if 0 == g:buftabline_show
-		set showtabline=1
+		set showtabline=0
 		return
-	elseif 1 == g:buftabline_show
+	endif
+	if tabpagenr('$') > 1 | set guioptions+=e showtabline=2 | return | endif
+	if 1 == g:buftabline_show
 		" account for BufDelete triggering before buffer is actually deleted
 		let bufnums = filter(buftabline#user_buffers(), 'v:val != a:zombie')
 		let &g:showtabline = 1 + ( len(bufnums) > 1 )


### PR DESCRIPTION
There is an [issue](https://github.com/junegunn/goyo.vim/issues/171) with this plugin when used with [Goyo](https://github.com/junegunn/goyo.vim).

This is how one can reproduce issue and test patch:

```
autocmd! User GoyoEnter nested call <SID>GoyoEnter()
autocmd! User GoyoLeave nested call <SID>GoyoLeave()

function! s:GoyoEnter() "
    "disable buftabline
    let g:buftabline_show = 0
    :call buftabline#update(0)
endfunction "

function! s:GoyoLeave() "
    "enable buftabline
    let g:buftabline_show = 2
    :call buftabline#update(0)
endfunction "
```

Actually issue have something to do with `buftabline` incorrectly populate tabline when Goyo mode is on. My fix just moves optimization `if tabpagenr('$') > 1 | set guioptions+=e showtabline=2 | return | endif`  below `if 0 == g:buftabline_show` check. This ensures that `let g:buftabline_show = 0` will always do what is expected from it - completely disable and hide buftabline.
