### PR TITLE
Document last buffer mapping

### DIFF
--- a/doc/buftabline.txt
+++ b/doc/buftabline.txt
@@ -87,6 +87,9 @@ map keys to the |<Plug>| mappings provided by this plugin: >
         nmap <leader>9 <Plug>BufTabLine.Go(9)
         nmap <leader>0 <Plug>BufTabLine.Go(10)
 <
+You can also add a mapping to go to the last buffer (as used in web browsers).: >
+        nmap <leader>9 <Plug>BufTabLine.Go(-1)
+<
 On Mac OS, you probably want to use a |<D-| mapping instead, which will emulate
 the standard Cmd+1, Cmd+2, etc. keybindings for this feature: >
         nmap <D-1> <Plug>BufTabLine.Go(1)


### PR DESCRIPTION
Adds an example for this feature so it's more searchable.

Issue: https://github.com/ap/vim-buftabline/issues/45
Commit: https://github.com/ap/vim-buftabline/commit/ca73a4e1242c75c2e3df3e8051192cca4c017b5e